### PR TITLE
Use `redisURL` for configuring Redis instead of multiple variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,13 +38,18 @@ func main() {
 			go metrics.ExposeMetrics(metricsConfig, logger)
 		}
 
-		pluginInstance.Impl.RedisAddress = cast.ToString(cfg["redisAddress"])
+		pluginInstance.Impl.RedisURL = cast.ToString(cfg["redisURL"])
 		pluginInstance.Impl.Expiry = cast.ToDuration(cfg["expiry"])
 		pluginInstance.Impl.DefaultDBName = cast.ToString(cfg["defaultDBName"])
+
+		redisConfig, err := redis.ParseURL(pluginInstance.Impl.RedisURL)
+		if err != nil {
+			logger.Error("Failed to parse Redis URL", "error", err)
+			os.Exit(1)
+		}
+
 		pluginInstance.Impl.RedisStore = redis_store.NewRedis(
-			redis.NewClient(&redis.Options{
-				Addr: pluginInstance.Impl.RedisAddress,
-			}),
+			redis.NewClient(redisConfig),
 		)
 	}
 

--- a/plugin/module.go
+++ b/plugin/module.go
@@ -33,7 +33,7 @@ var (
 			"metricsUnixDomainSocket": sdkConfig.GetEnv(
 				"METRICS_UNIX_DOMAIN_SOCKET", "/tmp/gatewayd-plugin-cache.sock"),
 			"metricsEndpoint": sdkConfig.GetEnv("METRICS_ENDPOINT", "/metrics"),
-			"redisAddress":    sdkConfig.GetEnv("REDIS_ADDRESS", "localhost:6379"),
+			"redisURL":        sdkConfig.GetEnv("REDIS_URL", "redis://localhost:6379/0"),
 			"expiry":          sdkConfig.GetEnv("EXPIRY", "1h"),
 			"defaultDBName":   sdkConfig.GetEnv("DEFAULT_DB_NAME", ""),
 		},

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -25,7 +25,7 @@ type Plugin struct {
 
 	Logger        hclog.Logger
 	RedisStore    *redis.RedisStore
-	RedisAddress  string
+	RedisURL      string
 	Expiry        time.Duration
 	DefaultDBName string
 }


### PR DESCRIPTION
Closes #13.