### PR TITLE
Improve Makefile by combining all build targets for different platforms into a single target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
 PLUGIN_NAME=gatewayd-plugin-cache
-PROJECT_URL=github.com/gatewayd-io/gatewayd
-CONFIG_PACKAGE=${PROJECT_URL}/config
+PROJECT_URL=github.com/gatewayd-io/$(PLUGIN_NAME)
+CONFIG_PACKAGE=${PROJECT_URL}/plugin
 LAST_TAGGED_COMMIT=$(shell git rev-list --tags --max-count=1)
-VERSION=$(shell git describe --tags ${LAST_TAGGED_COMMIT})
-TIMESTAMP=$(shell date -u +"%FT%T%z")
-VERSION_DETAILS=${TIMESTAMP}/${LAST_TAGGED_COMMIT_SHORT}
-EXTRA_LDFLAGS=-X ${CONFIG_PACKAGE}.Version=${VERSION} -X ${CONFIG_PACKAGE}.VersionDetails=${VERSION_DETAILS}
+VERSION=$(shell git describe --tags ${LAST_TAGGED_COMMIT}) | sed 's/^v//'
+EXTRA_LDFLAGS=-X ${CONFIG_PACKAGE}.Version=${VERSION}
 FILES=$(PLUGIN_NAME) checksum.txt gatewayd_plugin.yaml README.md LICENSE
 
 tidy:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VERSION=$(shell git describe --tags ${LAST_TAGGED_COMMIT})
 TIMESTAMP=$(shell date -u +"%FT%T%z")
 VERSION_DETAILS=${TIMESTAMP}/${LAST_TAGGED_COMMIT_SHORT}
 EXTRA_LDFLAGS=-X ${CONFIG_PACKAGE}.Version=${VERSION} -X ${CONFIG_PACKAGE}.VersionDetails=${VERSION_DETAILS}
-FILES=gatewayd-plugin-cache checksum.txt gatewayd_plugin.yaml README.md LICENSE
+FILES=$(PLUGIN_NAME) checksum.txt gatewayd_plugin.yaml README.md LICENSE
 
 tidy:
 	@go mod tidy
@@ -15,7 +15,7 @@ test:
 	@go test -v ./...
 
 checksum:
-	@sha256sum -b gatewayd-plugin-cache
+	@sha256sum -b $(PLUGIN_NAME)
 
 update-all:
 	@go get -u ./...

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PLUGIN_NAME=gatewayd-plugin-cache
 PROJECT_URL=github.com/gatewayd-io/gatewayd
 CONFIG_PACKAGE=${PROJECT_URL}/config
 LAST_TAGGED_COMMIT=$(shell git rev-list --tags --max-count=1)
@@ -25,58 +26,24 @@ build-dev: tidy
 create-build-dir:
 	@mkdir -p dist
 
-build-linux-amd64: tidy
-	@echo "Building gatewayd ${VERSION} for linux-amd64"
-	@mkdir -p dist/linux-amd64
-	@cp README.md LICENSE gatewayd_plugin.yaml ./dist/linux-amd64/
-	@GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w ${EXTRA_LDFLAGS}" -o dist/linux-amd64/gatewayd-plugin-cache
-	@sha256sum dist/linux-amd64/gatewayd-plugin-cache | sed 's/dist\/linux-amd64\///g' >> dist/linux-amd64/checksum.txt
-	@tar czf dist/gatewayd-plugin-cache-linux-amd64-${VERSION}.tar.gz -C ./dist/linux-amd64/ ${FILES}
-	@sha256sum dist/gatewayd-plugin-cache-linux-amd64-${VERSION}.tar.gz | sed 's/dist\///g' >> dist/checksums.txt
+build-release: tidy create-build-dir
+	@echo "Building gatewayd ${VERSION} for release"
+	@$(MAKE) build-platform GOOS=linux GOARCH=amd64 OUTPUT_DIR=dist/linux-amd64
+	@$(MAKE) build-platform GOOS=linux GOARCH=arm64 OUTPUT_DIR=dist/linux-arm64
+	@$(MAKE) build-platform GOOS=darwin GOARCH=amd64 OUTPUT_DIR=dist/darwin-amd64
+	@$(MAKE) build-platform GOOS=darwin GOARCH=arm64 OUTPUT_DIR=dist/darwin-arm64
+	@$(MAKE) build-platform GOOS=windows GOARCH=amd64 OUTPUT_DIR=dist/windows-amd64
+	@$(MAKE) build-platform GOOS=windows GOARCH=arm64 OUTPUT_DIR=dist/windows-arm64
 
-build-linux-arm64:
-	@echo "Building gatewayd ${VERSION} for linux-arm64"
-	@mkdir -p dist/linux-arm64
-	@cp README.md LICENSE gatewayd_plugin.yaml ./dist/linux-arm64/
-	@GOOS=linux GOARCH=arm64 CGO_ENABLED=0 CC=aarch64-linux-gnu-gcc go build -trimpath -ldflags "-s -w ${EXTRA_LDFLAGS}" -o dist/linux-arm64/gatewayd-plugin-cache
-	@sha256sum dist/linux-arm64/gatewayd-plugin-cache | sed 's/dist\/linux-arm64\///g' >> dist/linux-arm64/checksum.txt
-	@tar czf dist/gatewayd-plugin-cache-linux-arm64-${VERSION}.tar.gz -C ./dist/linux-arm64/ ${FILES}
-	@sha256sum dist/gatewayd-plugin-cache-linux-arm64-${VERSION}.tar.gz | sed 's/dist\///g' >> dist/checksums.txt
-
-build-darwin-amd64:
-	@echo "Building gatewayd ${VERSION} for darwin-arm64"
-	@mkdir -p dist/darwin-amd64
-	@cp README.md LICENSE gatewayd_plugin.yaml ./dist/darwin-amd64/
-	@GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w ${EXTRA_LDFLAGS}" -o dist/darwin-amd64/gatewayd-plugin-cache
-	@shasum -a 256 dist/darwin-amd64/gatewayd-plugin-cache | sed 's/dist\/darwin-amd64\///g' >> dist/darwin-amd64/checksum.txt
-	@tar czf dist/gatewayd-plugin-cache-darwin-amd64-${VERSION}.tar.gz -C ./dist/darwin-amd64/ ${FILES}
-	@shasum -a 256 dist/gatewayd-plugin-cache-darwin-amd64-${VERSION}.tar.gz | sed 's/dist\///g' >> dist/checksums.txt
-
-build-darwin-arm64:
-	@echo "Building gatewayd ${VERSION} for darwin-arm64"
-	@mkdir -p dist/darwin-arm64
-	@cp README.md LICENSE gatewayd_plugin.yaml ./dist/darwin-arm64/
-	@GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w ${EXTRA_LDFLAGS}" -o dist/darwin-arm64/gatewayd-plugin-cache
-	@shasum -a 256 dist/darwin-arm64/gatewayd-plugin-cache | sed 's/dist\/darwin-arm64\///g' >> dist/darwin-arm64/checksum.txt
-	@tar czf dist/gatewayd-plugin-cache-darwin-arm64-${VERSION}.tar.gz -C ./dist/darwin-arm64/ ${FILES}
-	@shasum -a 256 dist/gatewayd-plugin-cache-darwin-arm64-${VERSION}.tar.gz | sed 's/dist\///g' >> dist/checksums.txt
-
-build-windows-amd64:
-	@echo "Building gatewayd ${VERSION} for windows-amd64"
-	@mkdir -p dist/windows-amd64
-	@cp README.md LICENSE gatewayd_plugin.yaml ./dist/windows-amd64/
-	@GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w ${EXTRA_LDFLAGS}" -o dist/windows-amd64/gatewayd-plugin-cache.exe
-	@sha256sum dist/windows-amd64/gatewayd-plugin-cache.exe | sed 's/dist\/windows-amd64\///g' >> dist/windows-amd64/checksum.txt
-	@zip -r dist/gatewayd-plugin-cache-windows-amd64-${VERSION}.zip -j ./dist/windows-amd64/
-	@sha256sum dist/gatewayd-plugin-cache-windows-amd64-${VERSION}.zip | sed 's/dist\///g' >> dist/checksums.txt
-
-build-windows-arm64:
-	@echo "Building gatewayd ${VERSION} for windows-arm64"
-	@mkdir -p dist/windows-arm64
-	@cp README.md LICENSE gatewayd_plugin.yaml ./dist/windows-arm64/
-	@GOOS=windows GOARCH=arm64 CGO_ENABLED=0 go build -trimpath -ldflags "-s -w ${EXTRA_LDFLAGS}" -o dist/windows-arm64/gatewayd-plugin-cache.exe
-	@sha256sum dist/windows-arm64/gatewayd-plugin-cache.exe | sed 's/dist\/windows-arm64\///g' >> dist/windows-arm64/checksum.txt
-	@zip -r dist/gatewayd-plugin-cache-windows-arm64-${VERSION}.zip -j ./dist/windows-arm64/
-	@sha256sum dist/gatewayd-plugin-cache-windows-arm64-${VERSION}.zip | sed 's/dist\///g' >> dist/checksums.txt
-
-build-release: tidy create-build-dir build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-arm64 build-windows-amd64 build-windows-arm64
+build-platform: tidy
+	@echo "Building gatewayd ${VERSION} for $(GOOS)-$(GOARCH)"
+	@mkdir -p $(OUTPUT_DIR)
+	@cp README.md LICENSE gatewayd_plugin.yaml $(OUTPUT_DIR)/
+	@GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -trimpath -ldflags "-s -w ${EXTRA_LDFLAGS}" -o $(OUTPUT_DIR)/$(PLUGIN_NAME)
+	@sha256sum $(OUTPUT_DIR)/$(PLUGIN_NAME) | sed 's#$(OUTPUT_DIR)/##g' >> $(OUTPUT_DIR)/checksum.txt
+	@if [ "$(GOOS)" = "windows" ]; then \
+		zip -q -r dist/$(PLUGIN_NAME)-$(GOOS)-$(GOARCH)-${VERSION}.zip -j $(OUTPUT_DIR)/; \
+	else \
+		tar czf dist/$(PLUGIN_NAME)-$(GOOS)-$(GOARCH)-${VERSION}.tar.gz -C $(OUTPUT_DIR)/ ${FILES}; \
+	fi
+	@sha256sum dist/$(PLUGIN_NAME)-$(GOOS)-$(GOARCH)-${VERSION}.* | sed '#dist/##g' >> dist/checksums.txt

--- a/plugin/module.go
+++ b/plugin/module.go
@@ -7,9 +7,10 @@ import (
 )
 
 var (
+	Version  = "0.0.1"
 	PluginID = v1.PluginID{
 		Name:      "gatewayd-plugin-cache",
-		Version:   "0.0.1",
+		Version:   Version,
 		RemoteUrl: "github.com/gatewayd-io/gatewayd-plugin-cache",
 	}
 	PluginMap = map[string]goplugin.Plugin{


### PR DESCRIPTION
# Ticket(s)

N/A

## Description

This PR will improve the Makefile by combining all the build targets for different platforms into a single target. This target, `build-platform`, can be copied for other plugins as well. Also, the `version` info will be injected into the binary on build.

## Related PRs

N/A

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) and type annotations to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [ ] I have added tests for my changes.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
